### PR TITLE
Add port 8080 and namespace variable to URL arg

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -33,13 +33,17 @@ spec:
         name: fluxcdbot
         args:
         - --token=$(TOKEN)
-        - --url=http://fluxcdbot.default.svc.cluster.local
+        - --url=http://fluxcdbot.$(NAMESPACE).svc.cluster.local:8080
         env:
         - name: TOKEN
           valueFrom:
             secretKeyRef:
               name: fluxcdbot
               key: token
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
This PR includes two changes:

- Adding Port `8080` to the arg `--url` as headless services do not map ports
- Makes the namespace part in the arg `--url` dynamically.

Note: For the namespace part, there may be other options as well: One could parse `/var/run/secrets/kubernetes.io/serviceaccount/namespace` or rely on the DNS in the cluster.